### PR TITLE
Fix format-code hook

### DIFF
--- a/pre-commit-hooks/format-code.hook
+++ b/pre-commit-hooks/format-code.hook
@@ -9,4 +9,4 @@
 # To enable this hook, rename this file to "pre-commit".
 
 mvn fmt:format
-git diff --name-only --cached | xargs -l git add
+git diff --name-only --cached --diff-filter=d | xargs -l git add


### PR DESCRIPTION
Exclude deleted files from git diff output (see `man git diff`) 
Fixes #5