### PR TITLE
Typos/minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ Contributions are _always_ welcome! Please see our [Contribution Guidelines](CON
 
 Note: The icon next to each script signifies what language it is written in.
 
-| icon                                                     | language | icon                                                 | language |
-| -------------------------------------------------------- | -------- | ---------------------------------------------------- | -------- |
-| <img width="14" src="bash-icon.png" alt="Bash Icon">     | `bash`   | <img width="14" src="perl-icon.png" alt="Perl Icon"> | `perl`   |
-| <img width="14" src="python-icon.png" alt="Python Icon"> | `python` |                                                      |          |
+| icon                                                     | language |
+| -------------------------------------------------------- | -------- |
+| <img width="14" src="bash-icon.png" alt="Bash Icon">     | `bash`   |
+| <img width="14" src="python-icon.png" alt="Python Icon"> | `python` |
+| <img width="14" src="perl-icon.png" alt="Perl Icon">     | `perl`   |
 
 ### commit-msg
 

--- a/tests/spell-check-md-files-test.bats
+++ b/tests/spell-check-md-files-test.bats
@@ -5,7 +5,7 @@ LOG="./tests/tests.log"
 logTest() {
     # $1 indicates the test status [PASS, FAIL]
     date >> "$LOG"
-    echo "missing apsell error test: $1" >> "$LOG"
+    echo "missing aspell error test: $1" >> "$LOG"
     echo "" >> "$LOG"
     echo "--------------------------------------------" >> "$LOG"
     echo "" >> "$LOG"

--- a/tests/spell-check-md-files-test.bats
+++ b/tests/spell-check-md-files-test.bats
@@ -30,10 +30,10 @@ teardown() {
 @test "aspell not found error" {
     run aspell -v
     if [ "$status" -eq 0 ]; then
-	logTest "PASS"
+        logTest "PASS"
     else
-	logTest "FAIL"
-	[ "$output" = "aspell is not installed" ]
+        logTest "FAIL"
+        [ "$output" = "aspell is not installed" ]
     fi
 }
 
@@ -41,10 +41,10 @@ teardown() {
 @test "spellcheck proper md" {
     runAspell=$(cat proper.md | aspell --lang=en list)
     if [ -z "$runAspell" ]; then
-	logTest "PASS"
+        logTest "PASS"
     else
-	logTest "FAIL"
-	[ "$output" = "aspell found spelling mistakes" ]
+        logTest "FAIL"
+        [ "$output" = "aspell found spelling mistakes" ]
     fi
 }
 
@@ -52,10 +52,10 @@ teardown() {
 @test "spellcheck faulty md" {
     runAspell=$(cat faulty.md | aspell --lang=en list)
     if [ -n "$runAspell" ]; then
-	logTest "PASS"
+        logTest "PASS"
     else
-	logTest "FAIL"
-	[ "$output" = "aspell didn't find spelling mistakes" ]
+        logTest "FAIL"
+        [ "$output" = "aspell didn't find spelling mistakes" ]
     fi
 }
 
@@ -63,9 +63,9 @@ teardown() {
 @test "unsupported language error" {
     runAspell=$(cat other_lang.md | aspell --lang=en list)
     if [ -z "$runAspell" ]; then
-	logTest "PASS"
+        logTest "PASS"
     else
-	logTest "FAIL"
-	[ "$output" = "aspell found spelling mistakes in unsupported lang" ]
+        logTest "FAIL"
+        [ "$output" = "aspell found spelling mistakes in unsupported lang" ]
     fi
 }


### PR DESCRIPTION
Fix a typo, re-tab (with spaces) `spell-check-md-files` test script, update layout on language table in README.