### PR TITLE
verify-name-and-email-test: preserve original (local) user.* config

### DIFF
--- a/tests/verify-name-and-email-test.bats
+++ b/tests/verify-name-and-email-test.bats
@@ -22,7 +22,7 @@ teardown() {
 
     # Don't leave behind an empty [user] section
     if [ -z "$(git config --local -l | grep ^user)" ]; then
-        git config --local --remove-section user
+        git config --local --remove-section user 2>/dev/null || true
     fi
 }
 

--- a/tests/verify-name-and-email-test.bats
+++ b/tests/verify-name-and-email-test.bats
@@ -2,17 +2,27 @@
 
 LOG="./tests/tests.log"
 
+setup() {
+    # Preserve original user name/email
+    ORIG_GIT_USER="$(git config --get --local user.name || true)"
+    ORIG_GIT_EMAIL="$(git config --get --local user.email || true)"
+}
+
 teardown() {
-    # Reset user.name to correct value
-    if [[ "$(git config user.name)" != "Lauren Stephenson" ]]; then
-        $(git config --unset-all user.name)
-        $(git config user.name "Lauren Stephenson")
+    # Restore original user name/email
+    git config --unset-all user.name
+    git config --unset-all user.email
+
+    if [ -n "$ORIG_GIT_USER"  ]; then
+        git config --local user.name "$ORIG_GIT_USER"
+    fi
+    if [ -n "$ORIG_GIT_EMAIL" ]; then
+        git config --local user.email "$ORIG_GIT_EMAIL"
     fi
 
-    # Reset user.email to correct value
-    if [[ "$(git config user.email)" != "compscilauren@gmail.com" ]]; then
-        $(git config --unset-all user.email)
-        $(git config user.email "compscilauren@gmail.com")
+    # Don't leave behind an empty [user] section
+    if [ -z "$(git config --local -l | grep ^user)" ]; then
+        git config --local --remove-section user
     fi
 }
 


### PR DESCRIPTION
Also, don't leave an empty '[user]' section behind.

Fixes bug #31.