### PR TITLE
Add "Automatically Manage Git Hooks with Direnv" to "Written Guides"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Note: The icon next to each script signifies what language it is written in.
 
 - [Git hooks and practical uses. Yes, even on Windows.](https://www.tygertec.com/git-hooks-practical-uses-windows/)
 
+- [Automatically Manage Git Hooks with Direnv](https://knpw.rs/blog/direnv-git-hooks)
+
 ## Video Guides
 
 - [Git Hooks Part 1 - Getting Started](https://www.youtube.com/watch?v=aB3eq52sZSU)


### PR DESCRIPTION
I recently wrote a blog post about managing git hooks with nothing other than [`direnv`](https://direnv.net/) (or even `make`). This approach is unique because it doesn't tie you down to a specific framework or technology and lets you use more generic tooling that can be used for any project.