### PR TITLE
Miscellaneous improvements to shell scripts

### DIFF
--- a/post-checkout-hooks/new-branch-alert.hook
+++ b/post-checkout-hooks/new-branch-alert.hook
@@ -14,7 +14,7 @@ from_hash=$1
 to_hash=$2
 checkout_type=$3
 branch_name=$(git rev-parse --abbrev-ref HEAD)
-from_branch_name=$(git name-rev --name-only $from_hash)
+from_branch_name=$(git name-rev --name-only "$from_hash")
 
 light_red='\033[1;31m'
 no_color='\033[0m'
@@ -25,19 +25,19 @@ containsElement () {
     return 1
 }
 
-if [ $checkout_type -ne 1 ]
+if [ "$checkout_type" -ne 1 ]
 then
-    exit 0 ; # Not a branch checkout
+    exit 0 # Not a branch checkout
 fi
 
-if [ $from_hash != $to_hash ]
+if [ "$from_hash" != "$to_hash" ]
 then
-    exit 0 ; # Not checking out a new branch
+    exit 0 # Not checking out a new branch
 fi
 
-if [ $branch_name == $from_branch_name ]
+if [ "$branch_name" = "$from_branch_name" ]
 then
-    exit 0 ; # Not checking out a new branch
+    exit 0 # Not checking out a new branch
 fi
 
 # Create a commit and display a message

--- a/pre-commit-hooks/search-term.hook
+++ b/pre-commit-hooks/search-term.hook
@@ -8,7 +8,7 @@
 # The hook should exit with non-zero status after issuing an appropriate
 # message if it stops the commit.
 #
-# Requirements: 
+# Requirements:
 #   * Bash
 #
 # To enable this hook, rename this file to "pre-commit".
@@ -27,6 +27,6 @@ SEARCH_TERM="FIXME:"
 if [[ $(git diff --cached | grep -E "^\+" | grep -v '+++ b/' | cut -c 2-) == *$SEARCH_TERM* ]]
 then
 	printf "${RED}Error:${NC} Found ${SEARCH_TERM} in attempted commit.\n"
-	printf "Please remove all occurances of ${SEARCH_TERM} before committing.\n"
+	printf '%s\n' "Please remove all occurances of ${SEARCH_TERM} before committing."
 	exit 1
 fi

--- a/pre-commit-hooks/spell-check-md-files.hook
+++ b/pre-commit-hooks/spell-check-md-files.hook
@@ -5,7 +5,7 @@
 # Used to check files with the .md extension (markdown) for spelling errors.
 # It will run each .md file through aspell and returns an exit code other than 0 when it matches.
 #
-# Requirements: 
+# Requirements:
 #   * Bash
 #
 # To enable this hook, rename this file to "pre-commit".
@@ -23,7 +23,7 @@ for file in $(find $SEARCH_DIR -type f -name "*.md");
         # Pass each .md file through aspell.
         do output=$(cat $file | aspell --lang=en list);
         if [[ $? != 0 ]]; then
-                echo -e "${RED}Error found in output${NC}, cannot continue." 
+                echo -e "${RED}Error found in output${NC}, cannot continue."
                 echo -e "Please check manually for aspell -c $file?"
                 exit 1
         elif [[ $output ]]; then

--- a/pre-push-hooks/prevent-bad-push.hook
+++ b/pre-push-hooks/prevent-bad-push.hook
@@ -9,7 +9,7 @@
 # The hook should exit with non-zero status after issuing an appropriate
 # message if it stops the push.
 #
-# Requirements: 
+# Requirements:
 #   * Bash
 #
 # To enable this hook, rename this file to "pre-push".
@@ -31,7 +31,7 @@ url="$2"
 
 z40=0000000000000000000000000000000000000000
 
-while read local_ref local_sha remote_ref remote_sha
+while read -r local_ref local_sha remote_ref remote_sha
 do
 	if [ "$local_sha" = $z40 ]
 	then
@@ -48,7 +48,7 @@ do
 		fi
 
 		# Check for WIP commit
-		commit=`git rev-list -n 1 --grep '^WIP' "$range"`
+		commit=$(git rev-list -n 1 --grep '^WIP' "$range")
 		if [ -n "$commit" ]
 		then
 			echo >&2 "Found WIP commit in $local_ref, not pushing"

--- a/pre-rebase-hooks/prevent-rebase.hook
+++ b/pre-rebase-hooks/prevent-rebase.hook
@@ -19,7 +19,7 @@
 # The hook should exit with non-zero status after issuing an appropriate
 # message if it stops the rebase.
 #
-# Requirements: 
+# Requirements:
 #   * Bash
 #
 # To enable this hook, rename this file to "pre-rebase".
@@ -30,15 +30,15 @@ if test "$#" = 2
 then
 	topic="refs/heads/$2"
 else
-	topic=`git symbolic-ref HEAD` ||
-	exit 0 ; # we do not interrupt rebasing detached HEAD
+	topic=$(git symbolic-ref HEAD) ||
+	exit 0 # we do not interrupt rebasing detached HEAD
 fi
 
 case "$topic" in
 refs/heads/??/*)
 	;;
 *)
-	exit 0 ; # we do not interrupt others.
+	exit 0 # we do not interrupt others.
 	;;
 esac
 
@@ -52,28 +52,28 @@ git show-ref -q "$topic" || {
 }
 
 # Is topic fully merged to master?
-not_in_master=`git rev-list --pretty=oneline ^master "$topic"`
+not_in_master=$(git rev-list --pretty=oneline ^master "$topic")
 if test -z "$not_in_master"
 then
 	echo >&2 "$topic is fully merged to master; better remove it."
-	exit 1 ;# we could allow it, but there is no point.
+	exit 1 # we could allow it, but there is no point.
 fi
 
 # Is topic ever merged to next? If so you should not be rebasing it.
-only_next_1=`git rev-list ^master "^$topic" ${publish} | sort`
-only_next_2=`git rev-list ^master           ${publish} | sort`
+only_next_1=$(git rev-list ^master "^$topic" ${publish} | sort)
+only_next_2=$(git rev-list ^master           ${publish} | sort)
 if test "$only_next_1" = "$only_next_2"
 then
-	not_in_topic=`git rev-list "^$topic" master`
+	not_in_topic=$(git rev-list "^$topic" master)
 	if test -z "$not_in_topic"
 	then
 		echo >&2 "$topic is already up to date with master"
-		exit 1 ; # we could allow it, but there is no point.
+		exit 1 # we could allow it, but there is no point.
 	else
 		exit 0
 	fi
 else
-	not_in_next=`git rev-list --pretty=oneline ^${publish} "$topic"`
+	not_in_next=$(git rev-list --pretty=oneline ^${publish} "$topic")
 	/usr/bin/perl -e '
 		my $topic = $ARGV[0];
 		my $msg = "* $topic has commits already merged to public branch:\n";

--- a/update-hooks/prevent-unannotated-tags.hook
+++ b/update-hooks/prevent-unannotated-tags.hook
@@ -8,7 +8,7 @@
 # The hook should exit with non-zero status after issuing an appropriate
 # message if it stops the push.
 #
-# Requirements: 
+# Requirements:
 #   * Bash
 #
 # To enable this hook, rename this file to "update".
@@ -44,7 +44,7 @@ if [ -z "$GIT_DIR" ]; then
 	exit 1
 fi
 
-if [ -z "$refname" -o -z "$oldrev" -o -z "$newrev" ]; then
+if [ -z "$refname" ] || [ -z "$oldrev" ] || [ -z "$newrev" ]; then
 	echo "usage: $0 <ref> <oldrev> <newrev>" >&2
 	exit 1
 fi
@@ -71,7 +71,7 @@ zero="0000000000000000000000000000000000000000"
 if [ "$newrev" = "$zero" ]; then
 	newrev_type=delete
 else
-	newrev_type=$(git cat-file -t $newrev)
+	newrev_type=$(git cat-file -t "$newrev")
 fi
 
 case "$refname","$newrev_type" in
@@ -93,7 +93,7 @@ case "$refname","$newrev_type" in
 		;;
 	refs/tags/*,tag)
 		# annotated tag
-		if [ "$allowmodifytag" != "true" ] && git rev-parse $refname > /dev/null 2>&1
+		if [ "$allowmodifytag" != "true" ] && git rev-parse "$refname" > /dev/null 2>&1
 		then
 			echo "*** Tag '$refname' already exists." >&2
 			echo "*** Modifying a tag is not allowed in this repository." >&2


### PR DESCRIPTION
Hai~,

This improves various parts of the shell scripts to

-  Avoid using variable interpolation within the first argument of `printf`
- Quoting to avoid word splitting
- Replace deprecated backticks with `$()`
- Remove extraneous `;` after `exit`
- Some other smaller miscellaneous things