### PR TITLE
add `dotenvx` - prevent committing your `.env` file to code with this pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Note: The icon next to each script signifies what language it is written in.
 
 ### pre-commit
 
+- [dotenvx](https://github.com/CompSciLauren/awesome-git-hooks/blob/master/pre-commit-hooks/dotenvx.hook) - Prevent committing your `.env` file(s) to code. <img width="14" src="bash-icon.png" alt="Bash Icon">
 - [format-code](https://github.com/CompSciLauren/awesome-git-hooks/blob/master/pre-commit-hooks/format-code.hook) - Run command to format code and re-add any files modified after formatting. <img width="14" src="bash-icon.png" alt="Bash Icon">
 - [search-term](https://github.com/CompSciLauren/awesome-git-hooks/blob/master/pre-commit-hooks/search-term.hook) - Fail commit if a specific term is found in the code. <img width="14" src="bash-icon.png" alt="Bash Icon">
 - [spell-check-md-files](https://github.com/CompSciLauren/awesome-git-hooks/blob/master/pre-commit-hooks/spell-check-md-files.hook) - Check files with .md extension for spelling errors. <img width="14" src="bash-icon.png" alt="Bash Icon">

--- a/pre-commit-hooks/dotenvx.hook
+++ b/pre-commit-hooks/dotenvx.hook
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Prevents you from accidentally committing your `.env` file(s) to code
+#
+# Requirements: 
+#   * Bash
+#   * dotenvx
+#
+# To enable this hook, install dotnevx [https://dotenvx.com/docs/install] and rename this file to "pre-commit".
+
+dotenvx precommit


### PR DESCRIPTION
Hi Lauren,

Great resource. I'm the creator of [`dotenvx`](https://github.com/motdotla/dotenv) and have just created this `dotenvx precommit` It helps protect devs from committing their `.env` files to code. Adding it here to your awesome list.

<img width="684" alt="image" src="https://github.com/CompSciLauren/awesome-git-hooks/assets/3848/71ba0776-6e05-4457-9c0e-1f8cb5e9949c">

