### PR TITLE
Add push-sentinel to Tools: pre-push secret scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Note: The icon next to each script signifies what language it is written in.
 
 ## Tools
 
+- [push-sentinel](https://github.com/Pmaind/pre-push-secrets) - Pre-push hook that scans commits for secrets and API keys before they reach GitHub. Zero dependencies, Node.js only.
+
 - [Husky](https://github.com/typicode/husky) - Manage Git hooks with a nice user interface.
 
 - [Overcommit](https://github.com/sds/overcommit) - A fully configurable and extendable Git hook manager.


### PR DESCRIPTION
## What is push-sentinel?

[push-sentinel](https://github.com/Pmaind/pre-push-secrets) is a zero-dependency Node.js CLI that installs as a `pre-push` git hook and scans the diff being pushed for secrets (API keys, tokens, private keys) before they reach GitHub.

- One-command install: `npx --yes --prefer-online push-sentinel@latest install`
- Zero dependencies (Node.js stdlib only)
- Node.js >= 16
- MIT license

npm: https://www.npmjs.com/package/push-sentinel