### PR TITLE
Add BeLikeNative Git Grammar Hook to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Note: The icon next to each script signifies what language it is written in.
 
 - [pre-commit](https://github.com/pre-commit/pre-commit) - A framework for managing and maintaining multi-language pre-commit hooks.
 
+- [BeLikeNative Git Grammar Hook](https://github.com/theluckystrike/bln-git-grammar-hook) - Pre-commit hook that checks grammar, spelling, and style in commit messages and documentation with 77 local rules.
+
 ## Written Guides
 
 - [Git hooks documentation at git-scm.com](https://git-scm.com/docs/githooks)


### PR DESCRIPTION
## What's being added
[BeLikeNative Git Grammar Hook](https://github.com/theluckystrike/bln-git-grammar-hook) — A pre-commit hook that checks grammar, spelling, and style in commit messages and documentation with 77 local rules.

## Links
- Repository: https://github.com/theluckystrike/bln-git-grammar-hook
- Documentation: https://github.com/theluckystrike/bln-git-grammar-hook#readme

## Why it fits
Added to the **Tools** section alongside Husky, Overcommit, and pre-commit. This hook specifically targets grammar and style checking in commit messages and markdown documentation — complementing the existing `spell-check-md-files` hook in the pre-commit section.

## Format
Follows the existing format: `- [Name](URL) - Description.`