### PR TITLE
Add dos commit-audit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Note: The icon next to each script signifies what language it is written in.
 
 - [pre-commit](https://github.com/pre-commit/pre-commit) - A framework for managing and maintaining multi-language pre-commit hooks.
 
+- [dos commit-audit](https://github.com/anthony-chaudhary/dos-kernel) - Pre-push gate that blocks a commit whose message claims work its diff doesn't contain.
+
 ## Written Guides
 
 - [Git hooks documentation at git-scm.com](https://git-scm.com/docs/githooks)


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to the **Tools** section.

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.